### PR TITLE
Fix broken schedule on course homepage

### DIFF
--- a/src/assets/scripts/get_schedule.jl
+++ b/src/assets/scripts/get_schedule.jl
@@ -4,50 +4,37 @@ let
     today = Dates.today()
 
     sections = metadata["sidebar"]
-    sections = [
-        @htl("""
-        $([
-            let
-                input = other_page.input
-                output = other_page.output
+    section_htmls = map(sections) do (section_id, _)
+        map(collections[section_id].pages) do other_page
+            output = other_page.output
 
-                name = get(output.frontmatter, "title", basename(input.relative_path))
-                desc = get(output.frontmatter, "description", nothing)
-                tags = get(output.frontmatter, "tags", String[])
-                date_str = get(output.frontmatter, "date", nothing)
+            name = get(output.frontmatter, "title", basename(other_page.input.relative_path))
+            desc = get(output.frontmatter, "description", nothing)
+            tags = get(output.frontmatter, "tags", String[])
+            date_str = get(output.frontmatter, "date", nothing)
 
-                if date_str !== nothing
-                    upcoming = try
-                        Dates.Date(string(date_str)) > today
-                    catch
-                        false
-                    end
+            date_str === nothing && return nothing
 
-                    class = [
-                        "no-decoration",
-                        upcoming ? "upcoming-entry" : nothing,
-                        ("tag_$(replace(x, " "=>"_"))" for x in tags)...,
-                    ]
+            upcoming = try
+                Dates.Date(string(date_str)) > today
+            catch
+                false
+            end
 
-                    @htl("""<a title=$(desc) class=$(class) href=$(root_url * "/" * other_page.url)>
-                        <h3>$(name)</h3>
-                        <span class="schedule-date $(upcoming ? "upcoming-badge" : "")">$(date_str)</span>
-                        $(upcoming ? @htl("""<span class="upcoming-label">Upcoming</span>""") : nothing)
-                    </a>""")
-                else
-                    nothing
-                end
-            end for other_page in collections[section_id].pages
-        ])
-        """)
-        for (section_id, section_name) in sections
-    ]
+            class = [
+                "no-decoration",
+                upcoming ? "upcoming-entry" : nothing,
+                ("tag_$(replace(x, " "=>"_"))" for x in tags)...,
+            ]
 
-    isempty(sections) ? nothing : @htl("""<div class="wide subjectscontainer">
-    <h1>Schedule</h1>
-    <div class="subjects">
-      $(sections)
-    </div>
-    </div>
-    """)
+            # NOTE: keep each entry on a single line with no blank/whitespace-only
+            # lines. This output is interpolated into a Markdown (`.jlmd`) file, and
+            # the CommonMark processor ends a raw-HTML block on the first blank line,
+            # which would otherwise wrap the remaining cards in `<p>` and mis-nest the
+            # anchors (titles get hoisted out of their cards).
+            @htl("""<a title=$(desc) class=$(class) href=$(root_url * "/" * other_page.url)><h3>$(name)</h3><span class="schedule-date $(upcoming ? "upcoming-badge" : "")">$(date_str)</span>$(upcoming ? @htl("""<span class="upcoming-label">Upcoming</span>""") : nothing)</a>""")
+        end
+    end
+
+    isempty(section_htmls) ? nothing : @htl("""<div class="wide subjectscontainer"><h1>Schedule</h1><div class="subjects">$(section_htmls)</div></div>""")
 end

--- a/src/assets/scripts/get_subjects.jl
+++ b/src/assets/scripts/get_subjects.jl
@@ -1,3 +1,7 @@
+# NOTE: if you re-enable this in `_includes/welcome.jlmd`, collapse each card to a
+# single line with no blank/whitespace-only lines first — see the comment in
+# `get_schedule.jl`. The multi-line `@htl` cards below break when interpolated into
+# Markdown (CommonMark ends the raw-HTML block on the first blank line).
 let
     sections = metadata["sidebar"]
     sections = [


### PR DESCRIPTION
## Summary

The schedule on the deployed homepage (https://vchuravy.dev/rse-course/2026/) was broken in two ways. This fixes both.

### 1. Module 2 dates were a year off (`a5ab7a9`)
All three Module 2 notebooks had `date = "2025-…"` in their frontmatter instead of `2026`. The schedule generator compares each page's `date` against `today()` to order entries and flag "Upcoming", so these sessions sorted into the past and never got the upcoming badge.

- `github_and_package_manager.jl`: `2025-05-14` → `2026-05-14`
- `numerical_reproducibility.jl`: `2025-05-21` → `2026-05-21`
- `debugging.jl`: `2025-05-28` → `2026-05-28`

### 2. Card titles detached from their date boxes (`cad5383`)
`get_schedule.jl`'s output is interpolated into a Markdown (`.jlmd`) file. CommonMark ends a raw-HTML block at the first blank line, so the previous multi-line card templates (which included a whitespace-only line from the "Upcoming" label's `nothing` branch) caused stray `<p>` injection and mis-nested `</a>`. The browser then hoisted each `<h3>` title out of its `<a>` card, leaving titles floating next to empty date-only boxes.

**Fix:** emit each card on a single line with no blank/whitespace-only lines, so CommonMark passes the whole schedule through verbatim as one HTML block. Verified the rendered output is a single line with zero blank lines, dateless pages are skipped, and the "Upcoming" badge still renders.

### Cleanups (via `/simplify`)
- Flattened nested comprehensions into `map`, dropped an unused binding, removed a redundant per-section `@htl` wrapper.
- Added a pointer comment in the (currently disabled) `get_subjects.jl`, which carries the same latent CommonMark bug, so it doesn't silently regress if re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)